### PR TITLE
Update JGit and fix NPE when the description of a repository is not set

### DIFF
--- a/build.moxie
+++ b/build.moxie
@@ -106,7 +106,7 @@ properties: {
   slf4j.version  : 1.7.12
   wicket.version : 1.4.22
   lucene.version : 4.10.4
-  jgit.version   : 4.8.0.201706111038-r
+  jgit.version   : 4.9.2.201712150930-r
   groovy.version : 2.4.4
   bouncycastle.version : 1.52
   selenium.version : 2.28.0

--- a/src/main/java/com/gitblit/wicket/pages/RepositoryPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/RepositoryPage.java
@@ -311,7 +311,7 @@ public abstract class RepositoryPage extends RootPage {
 				} else {
 					add(new Fragment("repoIcon", "cloneIconFragment", this));
 				}
-				add(new Label("originRepository", Optional.of(model.description).or("")));
+				add(new Label("originRepository", Optional.fromNullable(model.description).or("")));
 			}
 		} else {
 			RepositoryModel origin = app().repositories().getRepositoryModel(model.originRepository);
@@ -322,7 +322,7 @@ public abstract class RepositoryPage extends RootPage {
 				} else {
 					add(new Fragment("repoIcon", "cloneIconFragment", this));
 				}
-				add(new Label("originRepository", Optional.of(model.description).or("")));
+				add(new Label("originRepository", Optional.fromNullable(model.description).or("")));
 			} else if (!user.canView(origin)) {
 				// show origin repository without link
 				add(new Fragment("repoIcon", "forkIconFragment", this));


### PR DESCRIPTION
This PR updates the JGit version to 4.9.2 and fixes a NPE when the description of a repo is not set.
This NPE has caused Internal Server Error messages when using Gitblit WebGUI in the past.