### PR TITLE
Fix "size limit exceeded" LDAPSearchException

### DIFF
--- a/src/main/distrib/data/defaults.properties
+++ b/src/main/distrib/data/defaults.properties
@@ -1700,7 +1700,7 @@ realm.container.autoCreateAccounts = false
 #
 # SINCE 1.7.0
 realm.container.autoAccounts.displayName = 
-realm.container.autoAccounts.emailAddress = 
+realm.container.autoAccounts.emailAddress =
 realm.container.autoAccounts.locale = 
 
 # If the user's created by the webapp container is given this role,
@@ -1951,6 +1951,13 @@ realm.ldap.syncPeriod = 5 MINUTES
 #
 # SINCE 1.4.0
 realm.ldap.removeDeletedUsers = true
+
+# Size of page (number of results which will be retrieved at once) when querying LDAP server
+#
+# If left blank, 100 is assumed
+#
+# SINCE 1.8.1
+realm.ldap.searchPageSize = 100
 
 # URL of the Redmine.
 #

--- a/src/test/config/test-ui-gitblit.properties
+++ b/src/test/config/test-ui-gitblit.properties
@@ -1071,6 +1071,13 @@ realm.ldap.displayName = displayName
 # SINCE 1.0.0
 realm.ldap.email = email
 
+# Size of page (number of results which will be retrieved at once) when querying LDAP server
+#
+# If left blank, 100 is assumed
+#
+# SINCE 1.8.1
+realm.ldap.searchPageSize = 100
+
 # The RedmineUserService must be backed by another user service for standard user
 # and team management.
 # default: users.conf


### PR DESCRIPTION
This exception is thrown when an LDAP query returns more results than
the LDAP server allows returning at once.

This commit enables Gitblit to retrieve 100 LDAP requests at once until no more
results are available.

Issue: INFRABRBA-3591