### PR TITLE
Make "canManage" permission case insensitive

### DIFF
--- a/src/main/java/com/gitblit/models/TeamModel.java
+++ b/src/main/java/com/gitblit/models/TeamModel.java
@@ -360,7 +360,7 @@ public class TeamModel implements Serializable, Comparable<TeamModel> {
 			}
 
 			if(permissions.get(key) == AccessPermission.MANAGE_PROJECT
-					&& projectName.matches(key)) {
+					&& StringUtils.matchesIgnoreCase(projectName, key)) {
 				return true;
 			}
 		}

--- a/src/main/java/com/gitblit/models/UserModel.java
+++ b/src/main/java/com/gitblit/models/UserModel.java
@@ -464,7 +464,7 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 
 		for(String key : permissions.keySet()) {
 			if(permissions.get(key) == AccessPermission.MANAGE_PROJECT
-					&& projectName.matches(key)) {
+					&& StringUtils.matchesIgnoreCase(projectName, key)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
This commit makes permission matching in `canManage()` (user and team) case insensitive, since permissions are saved lower case only.