### PR TITLE
Do not use GitBlitWebApp.get() for getting project models

### DIFF
--- a/src/main/java/com/gitblit/models/TeamModel.java
+++ b/src/main/java/com/gitblit/models/TeamModel.java
@@ -344,21 +344,12 @@ public class TeamModel implements Serializable, Comparable<TeamModel> {
 		return name.compareTo(o.name);
 	}
 
-    public boolean canManage(ProjectModel projectModel) {
-		if (projectModel == null) {
-			return false;
-		}
-
+    public boolean canManage(String projectName) {
 		if(canAdmin) {
 			return true;
 		}
 
 		for(String key : permissions.keySet()) {
-			String projectName = "/";
-			if(!projectModel.isRoot) {
-				projectName = projectModel.name + "/";
-			}
-
 			if(permissions.get(key) == AccessPermission.MANAGE_PROJECT
 					&& StringUtils.matchesIgnoreCase(projectName, key)) {
 				return true;

--- a/src/main/java/com/gitblit/models/UserModel.java
+++ b/src/main/java/com/gitblit/models/UserModel.java
@@ -449,22 +449,22 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 	}
 
 
-	public boolean canManage(String repository) {
-		return canManage(GitBlitWebApp.get().projects().getProjectModel(repository));
+	public boolean canManage(ProjectModel projectModel) {
+		String projectName = "/";
+		if(!projectModel.isRoot) {
+			projectName = projectModel.name + "/";
+		}
+
+		return canManage(projectName);
 	}
 
-	public boolean canManage(ProjectModel projectModel) {
-		if (projectModel == null) {
+	public boolean canManage(String projectName) {
+		if (StringUtils.isEmpty(projectName)) {
 			return false;
 		}
 
 		if(canAdmin()) {
 			return true;
-		}
-
-		String projectName = "/";
-		if(!projectModel.isRoot) {
-			projectName = projectModel.name + "/";
 		}
 
 		for(String key : permissions.keySet()) {
@@ -475,7 +475,7 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 		}
 
 		for(TeamModel teamModel : teams) {
-			if(teamModel.canManage(projectModel)) {
+			if(teamModel.canManage(projectName)) {
 				return true;
 			}
 		}
@@ -575,7 +575,8 @@ public class UserModel implements Principal, Serializable, Comparable<UserModel>
 	 * @return true if the user can create the repository
 	 */
 	public boolean canCreate(String repository) {
-		return canAdmin() || canManage(repository) || (canCreate() && isMyPersonalRepository(repository));
+		String projectName = StringUtils.getFirstPathElement(repository) + "/";
+		return canAdmin() || canManage(projectName) || (canCreate() && isMyPersonalRepository(repository));
 	}
 
 	/**


### PR DESCRIPTION
This commit removes `GitBlitWebApp.get().projects().getProjectModel()` for getting the project model and replaces it with a simple String operation.